### PR TITLE
added contribute.sh and moved repo/wp locations to environment variables #9

### DIFF
--- a/web-fort/README.md
+++ b/web-fort/README.md
@@ -12,23 +12,29 @@ SITE** so please exercise caution when closing PRs or modifying `origin/master` 
 
 ### Getting started
 
+To make sure you have the required tools to develop on web-fort, run our contributor script:
+
+```
+./contribute.sh
+```
+
 Download a copy of the production backup database from WPEngine by [requesting a production backup point](https://my.wpengine.com/installs/treefortfest/backup_points#production). See Will or Josh for permission.
 
 Start docker -
 
 ```
-cd web-fort/
+cd $WEBFORT_THEME_ROOT
 docker-compose up
 ```
 
 Open a new terminal and type -
 ```
 cd ~/Downloads/
-unzip site-archive-treefortfest-live-1515213575-QwnFzNMQiiuv04gVCpMWDwByC6Q41TjteQPc.zip -d /tmp/treefortweb
+unzip site-archive-treefortfest-live-1515213575-QwnFzNMQiiuv04gVCpMWDwByC6Q41TjteQPc.zip -d $WEBFORT_ROOT
 mysql -h 127.0.0.1 -u root -peveryoneiswelcome -e "SET GLOBAL show_compatibility_56 = ON;"
-mysql -h 127.0.0.1 -u root -peveryoneiswelcome wordpress < ~/Downloads/wp-content/mysql.sql
+mysql -h 127.0.0.1 -u root -peveryoneiswelcome wordpress < $WEBFORT_ROOT/wp-content/mysql.sql
 mysql -h 127.0.0.1 -u root -peveryoneiswelcome wordpress -e "update wp_options set option_value = 'http://localhost' where option_name in ('siteurl','home')";
-cd $TREEFORT_DEV_ROOT/web-fort/
+cd $WEBFORT_THEME_ROOT
 yarn
 ./node_modules/.bin/grunt
 ```

--- a/web-fort/contribute.sh
+++ b/web-fort/contribute.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+GREEN="\x1B[92m"
+RED="\x1B[91m"
+NC="\x1B[39m"
+
+installed() {
+  echo -n "$1: "
+  which -s ${2:-$1} && echo -e "${GREEN}installed${NC}" || echo -e "${RED}not installed${NC}"
+}
+
+defined() {
+  echo -n "$1: "
+  [ ! -z $2 ] && echo -e "${GREEN}defined${NC}" || echo -e "${RED}undefined${NC}"
+}
+
+cat <<EOF
+This script will check your local environment and verify you have the tools necessary for developing on webfort
+The following tools are required to run webfort locally:
+
+EOF
+
+installed "yarn (https://yarnpkg.com/en/docs/install)" yarn
+installed "docker (https://docs.docker.com/install/)" docker-compose
+installed "mysql client (varies by OS; \`brew install mysql\` on macOS)" mysql
+defined "\$WEBFORT_THEME_ROOT (export WEBFORT_THEME_ROOT=$(cd "$(dirname "$BASH_SOURCE")" && pwd))" $WEBFORT_THEME_ROOT
+defined "\$WEBFORT_ROOT (export WEBFORT_ROOT=<path where you unzipped the production backup>)" $WEBFORT_ROOT
+
+cat <<EOF
+
+You will also need access to a production backup. Check out `dirname $BASH_SOURCE`/README.md for more info
+Once you have met all the prerequisites, following the "Getting Started" steps in `dirname $BASH_SOURCE`/README.md
+EOF

--- a/web-fort/docker-compose.yml
+++ b/web-fort/docker-compose.yml
@@ -5,8 +5,8 @@ wordpress:
   ports:
     - 80:80
   volumes:
-    - ~/dev/treefort/web-fort:/var/www/html/wp-content/themes/web-fort
-    - /tmp/treefortweb/:/var/www/html/
+    - $WEBFORT_THEME_ROOT:/var/www/html/wp-content/themes/web-fort
+    - $WEBFORT_ROOT:/var/www/html/
     - $HOME:$HOME
 
 mysql:


### PR DESCRIPTION
Notable changes here:
- New `contribute.sh`, which contributors can use to verify they have the appropriate tools installed
- The docker now uses `$WEBFORT_ROOT` and `$WEBFORT_THEME_ROOT` environment variables to reference wp backup and repo locations respectively